### PR TITLE
Explicitly specify the path of package indices

### DIFF
--- a/pypi_mirror.py
+++ b/pypi_mirror.py
@@ -247,7 +247,7 @@ def generate_root_html(pkg_names):
     {}
   </body>
 </html>"""
-    anchor_tmpl = '<a href="{0}">{1}</a>'
+    anchor_tmpl = '<a href="{0}/index.html">{1}</a>'
     anchors = "\n    ".join(
         anchor_tmpl.format(norm_name, name) for norm_name, name in pkg_names
     )


### PR DESCRIPTION
We are runing GCS and it will not replace/redirect 
`/some-package` to `/some-package/index.html`.