### PR TITLE
added pypi-mirror download support for pip --find-links option

### DIFF
--- a/pypi_mirror.py
+++ b/pypi_mirror.py
@@ -244,12 +244,15 @@ def download(
     no_build_isolation: Optional[bool] = False,
     pip: str = "pip",
     extra_index_url: Optional[str] = None,
+    find_links: Optional[str] = None,
 ) -> None:
     args = [pip, "download", "-d", dest]
     if index_url:
         args += ["--index-url", index_url]
     if extra_index_url:
         args += ["--extra-index-url", extra_index_url]
+    if find_links:
+        args += ["--find-links", find_links]
     if proxy:
         args += ["--proxy", proxy]
     if not allow_binary:
@@ -582,6 +585,13 @@ class DownloadCmd(DownloadDirCmd):
             help="add packages from the given requirements file. "
             "This option can be used multiple times.",
         )
+        parser.add_argument(
+            "-f",
+            "--find-links",
+            metavar="URL",
+            help="If a url or path to an html file, then parse for links to archives. "
+            "If a local path or file:// url, then look for archives in the directory listing.",
+        )
         parser.add_argument("pkg", nargs="*", metavar="PKG", help="package to download")
 
     def run(self, args: argparse.Namespace) -> None:
@@ -601,6 +611,7 @@ class DownloadCmd(DownloadDirCmd):
             no_build_isolation=args.no_build_isolation,
             pip=args.pip_executable,
             extra_index_url=args.extra_index_url,
+            find_links=args.find_links,
         )
         pkgs = args.pkg
         if not pkgs and not args.requirements:


### PR DESCRIPTION
This adds support for the pip --find-links option to the pypi-mirror download command.

That option allows for parsing links to archives from a html file and including archives from directories (see https://pip.pypa.io/en/stable/cli/pip_download/).


Lets look at an example where this might be usefull:

    pypi-mirror download -d ~/pypi/data -p pip3 -b --python-version 311 python-cinderclient==9.4.0 

will fail because oslo-utils depends on netifaces>=0.10.4. 

At the moment netifaces doesn't provide a wheel for python 3.11 (https://pypi.org/project/netifaces/#files) and probably won't in the near future since the project is in need of a new maintainer.

With this PR we can build a netifaces wheel for python 3.11 our self.

For this example just clone the project (https://github.com/al45tair/netifaces), cd into the directory and run 'python3.11 -m build'.

Now we can just pass the directory path to where the package is located to pypimirror:

    pypi-mirror download -d ~/pypi/data -p pip3 -b --python-version 311 --find-links /netifaces/dist/ python-cinderclient==9.4.0 

And it will sucessfully download python-cinderclient:

Successfully downloaded python-cinderclient keystoneauth1 oslo.i18n oslo.utils pbr PrettyTable requests stevedore certifi charset-normalizer debtcollector idna iso8601 netaddr netifaces os-service-types packaging pyparsing pytz PyYAML tzdata urllib3 wcwidth wrapt